### PR TITLE
use process.env.GOOGLE_TRANSLATE_API first

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ function updateTKK() {
         if (Number(window.TKK.split('.')[0]) === now) {
             resolve();
         } else {
-            got('https://translate.google.com').then(function (res) {
+            got(process.env.GOOGLE_TRANSLATE_API || 'https://translate.google.com').then(function (res) {
                 var code = res.body.match(/TKK=(.*?)\(\)\)'\);/g);
 
                 if (code) {


### PR DESCRIPTION
In some countries, we can not access https://translate.google.com directly, but we can access https://translate.google.cn, so it's better to add an environment to overwrite the default API path.